### PR TITLE
Changes from background agent bc-82512fb4-1120-4524-903f-49d50161beca

### DIFF
--- a/workflow_n8n_sumare.json
+++ b/workflow_n8n_sumare.json
@@ -1,0 +1,48 @@
+{
+  "name": "API - SUMARÉ",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "url": "https://api-relatorios.sumare.edu.br/api-sumare-eduit/v1/webhooks/",
+        "authentication": "none",
+        "options": {
+          "timeout": 10000,
+          "redirect": {
+            "redirect": {}
+          }
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "Bearer f6e2ede4-b3c1-4377-999b-14d52dd24516"
+            }
+          ]
+        }
+      },
+      "id": "1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6",
+      "name": "HTTP Request - Sumaré API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [
+        300,
+        400
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {},
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "1",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "your-instance-id"
+  },
+  "id": "workflow-id",
+  "tags": []
+}


### PR DESCRIPTION
Convert Make.com scenario to n8n workflow for Sumaré API integration.

This PR translates the Make.com HTTP module, including URL, GET method, Authorization header, timeout, and redirect settings, into a functional n8n HTTP Request node.

---
<a href="https://cursor.com/background-agent?bcId=bc-82512fb4-1120-4524-903f-49d50161beca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82512fb4-1120-4524-903f-49d50161beca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>